### PR TITLE
UI improvements: Hide GitHub button and adjust back to canvas positioning

### DIFF
--- a/packages/frontend/editor-ui/src/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/components/MainHeader/MainHeader.vue
@@ -90,9 +90,7 @@ const readOnly = computed(() => sourceControlStore.preferences.branchReadOnly);
 const isEnterprise = computed(
 	() => settingsStore.isQueueModeEnabled && settingsStore.isWorkerViewAvailable,
 );
-const showGitHubButton = computed(
-	() => !isEnterprise.value && !settingsStore.settings.inE2ETests && !githubButtonHidden.value,
-);
+const showGitHubButton = computed(() => false);
 
 watch(route, (to, from) => {
 	syncTabsWithRoute(to, from);

--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -889,8 +889,8 @@ $main-panel-width: 360px;
 
 .backToCanvas {
 	position: fixed;
-	top: var(--spacing-xs);
-	left: var(--spacing-l);
+	top: var(--spacing-s);
+	left: 220px;
 
 	span {
 		color: var(--color-ndv-back-font);


### PR DESCRIPTION
## Summary
- Hide GitHub button in main header by setting showGitHubButton to always return false
- Adjust back to canvas button positioning with increased top spacing and fixed left position

## Test plan
- [ ] Verify GitHub button is no longer visible in main header
- [ ] Check back to canvas button positioning in node details view
- [ ] Test UI layout and spacing adjustments

🤖 Generated with [Claude Code](https://claude.ai/code)