### PR TITLE
fix(branding): show only the Flow wordmark in expanded sidebar

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nLogo/Logo.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nLogo/Logo.vue
@@ -44,7 +44,7 @@ const containerClasses = computed(() => {
 
 <template>
 	<div :class="containerClasses" data-test-id="n8n-logo">
-		<LogoIcon :class="$style.logo" />
+		<LogoIcon v-if="!showLogoText" :class="$style.logo" />
 		<LogoText v-if="showLogoText" :class="$style.logoText" />
 		<slot />
 	</div>

--- a/packages/frontend/@n8n/design-system/src/components/N8nLogo/__snapshots__/Logo.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nLogo/__snapshots__/Logo.test.ts.snap
@@ -1,10 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Logo > renders the logo for authView location 1`] = `
-"<div class="logoContainer large" data-test-id="n8n-logo"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="29" fill="none" viewBox="0 0 76 46" class="logo">
-    <path fill="#F9F9F9" d="M41.83 5.8h6.84l-9.51 34.41h-6.89L24.41 15.7l-7.86 24.51H9.56L0 5.8h7.09l6.31 23.68L21.02 5.8h6.94l7.67 23.78L41.84 5.8z"></path>
-    <path fill="#FFD800" d="M73.16 20.78s-.04-.08-.08-.08c-5.42-.58-9.96-4.09-12-8.92-.55-1.3-.92-2.7-1.07-4.16 0 0-.04-.08-.08-.08s-.08.04-.08.08c-.16 1.46-.52 2.86-1.07 4.16-2.04 4.83-6.58 8.34-12 8.92 0 0-.08.04-.08.08s.04.08.08.08c5.42.58 9.96 4.09 12 8.92.55 1.3.92 2.7 1.07 4.16 0 .05.04.08.08.08s.08-.04.08-.08c.16-1.46.52-2.86 1.07-4.16 2.04-4.83 6.58-8.34 12-8.92 0 0 .08-.04.08-.08M73.57 10.6s0-.02-.02-.02a3.85 3.85 0 0 1-3.42-3.42c0-.01 0-.02-.02-.02s-.02 0-.02.02a3.85 3.85 0 0 1-3.42 3.42c-.01 0-.02 0-.02.02s0 .02.02.02a3.85 3.85 0 0 1 3.42 3.42s0 .02.02.02.02 0 .02-.02a3.85 3.85 0 0 1 3.42-3.42c.01 0 .02 0 .02-.02M76 32.64s-.02-.04-.04-.04a6.57 6.57 0 0 1-5.82-5.82c0-.02-.02-.04-.04-.04s-.04.02-.04.04a6.571 6.571 0 0 1-5.82 5.82c-.02 0-.04.02-.04.04s.02.04.04.04a6.57 6.57 0 0 1 5.82 5.82s.02.04.04.04.04-.02.04-.04a6.571 6.571 0 0 1 5.82-5.82c.02 0 .04-.02.04-.04"></path>
-  </svg><svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="0 0 202.69 74" class="logoText">
+"<div class="logoContainer large" data-test-id="n8n-logo">
+  <!--v-if--><svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="0 0 202.69 74" class="logoText">
     <defs>
       <style>
         .cls-1 {
@@ -26,7 +24,8 @@ exports[`Logo > renders the logo for authView location 1`] = `
     <circle cx="170.84" cy="18.64" r="4.52" class="cls-2"></circle>
     <path d="M166.31 45.76v-9.04c0-2.5 2.02-4.52 4.52-4.52h9.04" class="cls-2"></path>
     <circle cx="184.4" cy="32.2" r="4.52" class="cls-2"></circle>
-  </svg></div>"
+  </svg>
+</div>"
 `;
 
 exports[`Logo > renders the logo for sidebar location when sidebar is collapsed 1`] = `
@@ -39,10 +38,8 @@ exports[`Logo > renders the logo for sidebar location when sidebar is collapsed 
 `;
 
 exports[`Logo > renders the logo for sidebar location when sidebar is expanded 1`] = `
-"<div class="logoContainer sidebar sidebarExpanded" data-test-id="n8n-logo"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="29" fill="none" viewBox="0 0 76 46" class="logo">
-    <path fill="#F9F9F9" d="M41.83 5.8h6.84l-9.51 34.41h-6.89L24.41 15.7l-7.86 24.51H9.56L0 5.8h7.09l6.31 23.68L21.02 5.8h6.94l7.67 23.78L41.84 5.8z"></path>
-    <path fill="#FFD800" d="M73.16 20.78s-.04-.08-.08-.08c-5.42-.58-9.96-4.09-12-8.92-.55-1.3-.92-2.7-1.07-4.16 0 0-.04-.08-.08-.08s-.08.04-.08.08c-.16 1.46-.52 2.86-1.07 4.16-2.04 4.83-6.58 8.34-12 8.92 0 0-.08.04-.08.08s.04.08.08.08c5.42.58 9.96 4.09 12 8.92.55 1.3.92 2.7 1.07 4.16 0 .05.04.08.08.08s.08-.04.08-.08c.16-1.46.52-2.86 1.07-4.16 2.04-4.83 6.58-8.34 12-8.92 0 0 .08-.04.08-.08M73.57 10.6s0-.02-.02-.02a3.85 3.85 0 0 1-3.42-3.42c0-.01 0-.02-.02-.02s-.02 0-.02.02a3.85 3.85 0 0 1-3.42 3.42c-.01 0-.02 0-.02.02s0 .02.02.02a3.85 3.85 0 0 1 3.42 3.42s0 .02.02.02.02 0 .02-.02a3.85 3.85 0 0 1 3.42-3.42c.01 0 .02 0 .02-.02M76 32.64s-.02-.04-.04-.04a6.57 6.57 0 0 1-5.82-5.82c0-.02-.02-.04-.04-.04s-.04.02-.04.04a6.571 6.571 0 0 1-5.82 5.82c-.02 0-.04.02-.04.04s.02.04.04.04a6.57 6.57 0 0 1 5.82 5.82s.02.04.04.04.04-.02.04-.04a6.571 6.571 0 0 1 5.82-5.82c.02 0 .04-.02.04-.04"></path>
-  </svg><svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="0 0 202.69 74" class="logoText">
+"<div class="logoContainer sidebar sidebarExpanded" data-test-id="n8n-logo">
+  <!--v-if--><svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="0 0 202.69 74" class="logoText">
     <defs>
       <style>
         .cls-1 {
@@ -64,5 +61,6 @@ exports[`Logo > renders the logo for sidebar location when sidebar is expanded 1
     <circle cx="170.84" cy="18.64" r="4.52" class="cls-2"></circle>
     <path d="M166.31 45.76v-9.04c0-2.5 2.02-4.52 4.52-4.52h9.04" class="cls-2"></path>
     <circle cx="184.4" cy="32.2" r="4.52" class="cls-2"></circle>
-  </svg></div>"
+  </svg>
+</div>"
 `;


### PR DESCRIPTION
Removes the duplicated logo in the sidebar: the W✦ Workforce icon mark was rendering alongside the Flow wordmark (which already contains the node-box glyph) when the sidebar is expanded. Now the icon mark renders only when the wordmark is hidden (collapsed sidebar); expanded and auth views show just the Flow wordmark + node box.

- `Logo.vue`: `LogoIcon` gated on `v-if="!showLogoText"`
- Snapshots updated (auth + expanded no longer include the icon; collapsed unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)