### PR TITLE
fix(deploy): repo-root docker build context

### DIFF
--- a/.github/workflows/flow-deploy.yml
+++ b/.github/workflows/flow-deploy.yml
@@ -56,7 +56,7 @@ jobs:
             --build-arg N8N_RELEASE_TYPE=stable \
             -t $ECR_REGISTRY/$ECR_REPO:${{ steps.meta.outputs.image_tag }} \
             --load \
-            -f docker/images/n8n/Dockerfile compiled
+            -f docker/images/n8n/Dockerfile .
 
       - name: Trivy scan
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
The deploy workflow built the image with `compiled` as the docker context, but the Dockerfile COPYs (`./compiled`, `docker/images/n8n/docker-entrypoint.sh`) are relative to the repo root (per deploy/ec2/README.md). That made the build fail with "not found". Switch the context to `.`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)