### PR TITLE
fix(security): tmp 0.2.7 + ignore vendored picomatch ReDoS

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,11 @@
 # runtime either — Node.js uses its own bundled OpenSSL for crypto, not these
 # system libs. Re-evaluate on each upstream base bump.
 CVE-2026-45447
+
+# CVE-2026-33671 — picomatch ReDoS (HIGH). The pnpm graph resolves picomatch
+# to 4.0.4 (override "picomatch@4": "4.0.4"); this 4.0.3 copy is vendored
+# inside a transitive package's published tarball, so it is not in the lockfile
+# and cannot be rewritten by pnpm overrides. Fixable graph deps are bumped, not
+# ignored — this entry is only for the un-rewritable vendored copy. ReDoS is
+# DoS-only and not on a request-reachable path for n8n.
+CVE-2026-33671

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
       "date-fns-tz": "2.0.0",
       "form-data": "4.0.6",
       "pdf-parse": "catalog:",
-      "tmp": "0.2.6",
+      "tmp": "0.2.7",
       "nodemailer": "7.0.11",
       "validator": "13.15.26",
       "zod": "3.25.67",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,7 +499,7 @@ overrides:
   date-fns-tz: 2.0.0
   form-data: 4.0.6
   pdf-parse: 2.4.5
-  tmp: 0.2.6
+  tmp: 0.2.7
   nodemailer: 7.0.11
   validator: 13.15.26
   zod: 3.25.67
@@ -2615,8 +2615,8 @@ importers:
         specifier: 7.7.3
         version: 7.7.3
       tmp:
-        specifier: 0.2.6
-        version: 0.2.6
+        specifier: 0.2.7
+        version: 0.2.7
     devDependencies:
       '@n8n/vitest-config':
         specifier: workspace:*
@@ -20214,8 +20214,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.6:
-    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -24710,7 +24710,7 @@ snapshots:
       safe-regex2: 5.1.1
       source-map-support: 0.5.21
       stack-utils: 2.0.6
-      tmp: 0.2.6
+      tmp: 0.2.7
       tmp-promise: 3.0.3
       ts-pattern: 5.8.0
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -33908,7 +33908,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.6
+      tmp: 0.2.7
 
   extract-zip@2.0.1:
     dependencies:
@@ -34011,7 +34011,7 @@ snapshots:
     dependencies:
       readline-sync: 1.4.10
       sprintf-js: 1.1.3
-      tmp: 0.2.6
+      tmp: 0.2.7
 
   fetch-blob@3.2.0:
     dependencies:
@@ -39975,7 +39975,7 @@ snapshots:
     dependencies:
       '@bazel/runfiles': 6.5.0
       jszip: 3.10.1
-      tmp: 0.2.6
+      tmp: 0.2.7
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -40981,7 +40981,7 @@ snapshots:
       properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 2.1.4
-      tmp: 0.2.6
+      tmp: 0.2.7
       undici: 7.24.6
     transitivePeerDependencies:
       - supports-color
@@ -41041,9 +41041,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.6
+      tmp: 0.2.7
 
-  tmp@0.2.6: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
Bumps tmp to 0.2.7 (CVE-2026-49982). Ignores CVE-2026-33671 (picomatch ReDoS) — graph resolves to 4.0.4 but a vendored 4.0.3 copy inside a transitive tarball can't be rewritten by overrides; DoS-only, not reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)