### PR TITLE
fix(branding): dark text on solid (primary) buttons

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -237,7 +237,10 @@ const handleClick = (event: MouseEvent) => {
 		--button--color--background: var(--background--brand);
 		--button--color--background-hover: var(--background--brand--hover);
 		--button--color--background-active: var(--background--brand--active);
-		--button--color: var(--color--neutral-white);
+		// Text color on the brand background. Defaults to white (upstream's dark
+		// orange brand); the Flow rebrand sets a dark value via --button--solid--color--text
+		// because the brand is a light yellow that white text fails contrast on.
+		--button--color: var(--button--solid--color--text, var(--color--neutral-white));
 		--button--shadow: var(--shadow--xs);
 		--button--shadow--hover: var(--shadow--xs);
 		--button--shadow--active: var(--shadow--xs);

--- a/packages/frontend/@n8n/design-system/src/css/_flow-brand.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_flow-brand.scss
@@ -41,8 +41,12 @@
 	--color--orange-alpha-900: oklch(88.88% 0.1827 95.76 / 0.9);
 	--color--orange-alpha-950: oklch(88.88% 0.1827 95.76 / 0.95);
 
-	/* Yellow buttons need dark text (upstream uses white on orange) */
+	/* Yellow buttons need dark text (upstream uses white on orange).
+	 * --button--color--text--primary is the legacy token (N8nButton.legacy / el-button);
+	 * --button--solid--color--text drives the current N8nButton `solid` variant, whose
+	 * .solid CSS-module class hardcodes white and can't be reached from :root otherwise. */
 	--button--color--text--primary: rgb(32, 32, 32);
+	--button--solid--color--text: rgb(32, 32, 32);
 	--button--color--text--primary--disabled: #3d4551;
 	--button--border-color--primary--disabled: #ccc;
 	--button--color--background--primary--disabled: #ccc;


### PR DESCRIPTION
The 2.x N8nButton `solid` variant hardcoded white text in a hashed CSS-module class, so the legacy --button--color--text--primary override never applied — primary CTAs were white-on-yellow (low contrast). Make the solid text color a brand-controllable var and set it dark in _flow-brand.scss. danger/success keep white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)